### PR TITLE
change import namespace to github.com/xgen-cloud/mongo-lock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/square/mongo-lock
+module github.com/xgen-cloud/mongo-lock
 
 go 1.13
 

--- a/lock_test.go
+++ b/lock_test.go
@@ -15,7 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
-	lock "github.com/square/mongo-lock"
+	lock "github.com/xgen-cloud/mongo-lock"
 )
 
 func getRandomString() string {

--- a/purge_test.go
+++ b/purge_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	lock "github.com/square/mongo-lock"
+	lock "github.com/xgen-cloud/mongo-lock"
 )
 
 func TestPurge(t *testing.T) {


### PR DESCRIPTION
without changing the namespace from square here, go module tooling chokes when attempting to upgrade.

also moving this to an org fork instead of a personal fork